### PR TITLE
Fix of Customize button position in taskbar properties dialog for ja-JP

### DIFF
--- a/src/localization/ja-JP/dlg.ja-JP.rc
+++ b/src/localization/ja-JP/dlg.ja-JP.rc
@@ -79,7 +79,7 @@ LTEXT           "最近クリックしていないインジケータを隠すこ
 IDC_STATIC_NOTIFY, 13, 169, 223, 16
 CONTROL         "アクティブでないインジケータを隠す(&H)", IDC_NOTIFYMAN, "Button",
 BS_AUTOCHECKBOX | WS_TABSTOP, 13, 191, 136, 10
-PUSHBUTTON      "カスタマイズ(&C)...", IDC_CUSTOMIZE, 188, 191, 59, 14
+PUSHBUTTON      "カスタマイズ(&C)...", IDC_CUSTOMIZE, 179, 191, 59, 14
 
 GROUPBOX        "タスク バーのデザイン", IDC_STATIC, 6, 6, 240, 104
 GROUPBOX        "通知領域", IDC_STATIC, 6, 114, 240, 98


### PR DESCRIPTION
Before:
![customize-button-taskbar-propetries-before](https://raw.githubusercontent.com/HitAnyKey/Images/refs/heads/main/customize-button-taskbar-propetries-before.png)

After:
![customize-button-taskbar-propetries-after](https://raw.githubusercontent.com/HitAnyKey/Images/refs/heads/main/customize-button-taskbar-propetries-after.png)
