### PR TITLE
Use IsAppThemed instead of GetThemeAppProperties

### DIFF
--- a/src/Tray.cpp
+++ b/src/Tray.cpp
@@ -1841,7 +1841,7 @@ void CTray::_CreateTrayWindow()
 
 
     // Fix for DWM borders on classic theme
-    if (!(GetThemeAppProperties() & STAP_ALLOW_NONCLIENT))
+    if (!IsAppThemed())
     {
         DWMNCRENDERINGPOLICY ncrp = DWMNCRP_DISABLED;
         DwmSetWindowAttribute(_hwnd, DWMWA_NCRENDERING_POLICY, &ncrp, sizeof(DWMNCRENDERINGPOLICY));

--- a/src/localization/es-ES/explorer.es-ES.rc
+++ b/src/localization/es-ES/explorer.es-ES.rc
@@ -282,7 +282,7 @@ BEGIN
     IDS_TURNOFFCOMPUTER     "&Apagar equipo..."
 #ifdef WINNT
    IDS_OPENCOMMON    "Abrir &todos los usuarios"
-   IDS_EXPLORECOMMON "xplo&rar todos los usuarios"
+   IDS_EXPLORECOMMON "Explo&rar todos los usuarios"
 #endif
     IDS_STARTMENUPROP   "&Propiedades"
 


### PR DESCRIPTION
Unless explicitly set, GetThemeAppProperties() always returns the same flags, even if the theme section access is denied, use IsAppThemed() which will cover theme app properties flags and theme section access status.